### PR TITLE
exclude bluetooth from being detected as WIFI network

### DIFF
--- a/src/reyna.Facts/GivenAConnectionInfo.cs
+++ b/src/reyna.Facts/GivenAConnectionInfo.cs
@@ -259,5 +259,18 @@
             NetworkInterface.NetworkInterfaces = new INetworkInterface[] { usbNetworkInterface, lanNetworkInterface };
             Assert.False(this.ConnectionInfo.Wifi);
         }
+
+        [Fact]
+        public void WhenCallingWifiAndUsingBluetoothShouldReturnFalse()
+        {
+            var usbNetworkInterface = new NetworkInterface();
+            usbNetworkInterface.Name = "SS1VNDIS1";
+
+            var lanNetworkInterface = new NetworkInterface();
+            lanNetworkInterface.Speed = 10000000;
+
+            NetworkInterface.NetworkInterfaces = new INetworkInterface[] { usbNetworkInterface, lanNetworkInterface };
+            Assert.False(this.ConnectionInfo.Wifi);
+        }
     }
 }

--- a/src/reyna.Win32/Properties/AssemblyInfo.cs
+++ b/src/reyna.Win32/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0.48")]
-[assembly: AssemblyFileVersion("2.10.0.48")]
+[assembly: AssemblyVersion("2.11.0.49")]
+[assembly: AssemblyFileVersion("2.11.0.49")]
 [assembly: InternalsVisibleTo("reyna.Facts")]
 [assembly: InternalsVisibleTo("reyna.Integration.Facts")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/reyna/Connection/ConnectionInfo.cs
+++ b/src/reyna/Connection/ConnectionInfo.cs
@@ -119,7 +119,7 @@
         {
             foreach (var ni in interfaces)
             {
-                if (LANNetwork(ni) || ActiveSyncNetwork(ni) || GPRSNetwork(ni))
+                if (LANNetwork(ni) || ActiveSyncNetwork(ni) || GPRSNetwork(ni) || BluetoothNetwork(ni))
                 {
                     continue;
                 }
@@ -143,6 +143,11 @@
         private static bool LANNetwork(INetworkInterface ni)
         {
             return ni.Speed == 10000000 || ni.Speed == 100000000;
+        }
+
+        private static bool BluetoothNetwork(INetworkInterface ni)
+        {
+            return ni.Name.ToLower(System.Globalization.CultureInfo.CurrentCulture).StartsWith("ss1vndis", StringComparison.CurrentCulture);
         }
 
         private static bool NetworkConnected(INetworkInterface networkInterface)

--- a/src/reyna/Properties/AssemblyInfo.cs
+++ b/src/reyna/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.10.0.48")]
+[assembly: AssemblyVersion("2.11.0.49")]
 [assembly: InternalsVisibleTo("Reyna.Integration.Facts.dll")]
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("AcceptanceTests")]


### PR DESCRIPTION
Fix detecting WLAN network by excluding Bluetooth network adapter by name
